### PR TITLE
feat: 제약조건이 있는 DnD 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "html-webpack-plugin": "^5.6.0",
         "mini-css-extract-plugin": "^2.9.0",
         "prettier": "^3.3.3",
+        "ts-loader": "^9.5.1",
         "ts-node": "^10.9.2",
         "typescript": "^5.5.4",
         "webpack": "^5.93.0",
@@ -10683,6 +10684,117 @@
       },
       "peerDependencies": {
         "typescript": ">=4.2.0"
+      }
+    },
+    "node_modules/ts-loader": {
+      "version": "9.5.1",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.1.tgz",
+      "integrity": "sha512-rNH3sK9kGZcH9dYzC7CewQm4NtxJTjSEVRJ2DyBZR7f8/wcta+iV44UPCXc5+nzDzivKtlzV6c9P4e+oFhDLYg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "enhanced-resolve": "^5.0.0",
+        "micromatch": "^4.0.0",
+        "semver": "^7.3.4",
+        "source-map": "^0.7.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "typescript": "*",
+        "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/ts-loader/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ts-loader/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ts-loader/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/ts-loader/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/ts-loader/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ts-loader/node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ts-loader/node_modules/source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/ts-loader/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ts-node": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "html-webpack-plugin": "^5.6.0",
     "mini-css-extract-plugin": "^2.9.0",
     "prettier": "^3.3.3",
+    "ts-loader": "^9.5.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.5.4",
     "webpack": "^5.93.0",

--- a/src/component/DraggableItem/index.tsx
+++ b/src/component/DraggableItem/index.tsx
@@ -1,18 +1,23 @@
 import { Draggable } from 'react-beautiful-dnd'
-import { Item } from '../../data'
 import { ItemContainer } from './styled'
 
-const DraggableItem = ({ item, index }: { item: Item; index: number }) => (
+interface DraggableItemProps {
+  item: { id: number; content: string }
+  index: number
+  isInvalidDrop: boolean
+}
+
+const DraggableItem = ({ item, index, isInvalidDrop }: DraggableItemProps) => (
   <Draggable
-    key={item.id}
-    draggableId={item.id}
+    draggableId={item.id.toString()}
     index={index}>
     {(provided, snapshot) => (
       <ItemContainer
         ref={provided.innerRef}
         {...provided.draggableProps}
         {...provided.dragHandleProps}
-        isDragging={snapshot.isDragging}>
+        isDragging={snapshot.isDragging}
+        isInvalidDrop={isInvalidDrop}>
         {item.content}
       </ItemContainer>
     )}

--- a/src/component/DraggableItem/styled.ts
+++ b/src/component/DraggableItem/styled.ts
@@ -1,9 +1,13 @@
 import styled from '@emotion/styled'
 import { GRID } from '../../data'
 
-export const ItemContainer = styled.div<{ isDragging: boolean }>`
+export const ItemContainer = styled.div<{
+  isInvalidDrop: boolean
+  isDragging: boolean
+}>`
   user-select: none;
   padding: ${GRID * 2}px;
   margin: 0 0 ${GRID}px 0;
-  background: ${({ isDragging }) => (isDragging ? 'lightgreen' : 'grey')};
+  background: ${({ isInvalidDrop, isDragging }) =>
+    isInvalidDrop && isDragging ? 'red' : 'white'};
 `

--- a/src/component/ItemList/index.tsx
+++ b/src/component/ItemList/index.tsx
@@ -3,8 +3,14 @@ import { Item } from '../../data'
 import DraggableItem from '../DraggableItem'
 import { List } from './styled'
 
-const ItemList = ({ items }: { items: Item[] }) => (
-  <Droppable droppableId="droppable">
+interface ItemListProps {
+  items: Item[]
+  droppableId: string
+  isInvalidDrop: boolean
+}
+
+const ItemList = ({ items, droppableId, isInvalidDrop }: ItemListProps) => (
+  <Droppable droppableId={droppableId}>
     {(provided, snapshot) => (
       <List
         {...provided.droppableProps}
@@ -15,6 +21,7 @@ const ItemList = ({ items }: { items: Item[] }) => (
             key={item.id}
             item={item}
             index={index}
+            isInvalidDrop={isInvalidDrop}
           />
         ))}
         {provided.placeholder}

--- a/src/data.ts
+++ b/src/data.ts
@@ -1,14 +1,35 @@
 export interface Item {
-  id: string
+  id: number
   content: string
 }
 
-export const getItems = (count: number) =>
-  Array.from({ length: count }, (v, k) => k).map(k => ({
-    id: `item-${k}`,
-    content: `item ${k}`
+export interface Column {
+  id: string
+  title: string
+  items: Item[]
+}
+
+export const getItems = (count: number): Record<string, Column> => {
+  const columns: Record<string, Column> = {}
+
+  // 첫 번째 컬럼의 아이템 생성
+  const firstColumnItems: Item[] = Array.from({ length: 10 }, (_, index) => ({
+    id: index + 1,
+    content: `item-${index + 1}`
   }))
 
+  // 컬럼 생성
+  for (let i = 1; i <= count; i++) {
+    const columnId = `column-${i}`
+    columns[columnId] = {
+      id: columnId,
+      title: `Column ${i}`,
+      items: i === 1 ? firstColumnItems : []
+    }
+  }
+
+  return columns
+}
 export const reorder = (
   list: Item[],
   startIndex: number,
@@ -19,3 +40,5 @@ export const reorder = (
   result.splice(endIndex, 0, removed)
   return result
 }
+
+export const GRID = 8

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import ReactDOM from 'react-dom'
+import { createRoot } from 'react-dom/client'
 import App from './App'
 
-ReactDOM.render(<App />, document.getElementById('root'))
+createRoot(document.getElementById('root')!).render(<App />)

--- a/src/utils/dragConditionFn.ts
+++ b/src/utils/dragConditionFn.ts
@@ -1,5 +1,5 @@
 import { DragUpdate } from 'react-beautiful-dnd'
-import { Column } from '../data'
+import { Column, Item } from '../data'
 
 interface UpdateColumnItemsParams {
   sourceIndex: number
@@ -16,10 +16,13 @@ interface MoveItemBetweenColumnsParams {
   columns: Record<string, Column>
 }
 
-const isEven = (id: number) => {
-  return id % 2 === 0
+interface canDropItemWithoutCreatingEvenSequenceParams {
+  draggableId: string
+  destinationIndex: number
+  finishColumn: Column
 }
 
+//1->3 이동 불가 조건 및 짝수 나열 조건 처리
 export const isInvalidDropCondition = (
   { destination, source, draggableId }: DragUpdate,
   columns: Record<string, Column>
@@ -36,11 +39,11 @@ export const isInvalidDropCondition = (
   const finishColumn = columns[destination.droppableId]
 
   if (
-    draggableId &&
-    isEven(Number(draggableId)) &&
-    ((destination.index > 0 &&
-      isEven(finishColumn.items[destination.index - 1]?.id)) ||
-      isEven(finishColumn.items[destination.index]?.id))
+    canDropItemWithoutCreatingEvenSequence({
+      draggableId,
+      destinationIndex: destination.index,
+      finishColumn
+    })
   ) {
     return true
   }
@@ -48,6 +51,7 @@ export const isInvalidDropCondition = (
   return false
 }
 
+// 같은 Draggable내에서 업데이트
 export const updateColumnItems = ({
   sourceIndex,
   destinationIndex,
@@ -68,6 +72,7 @@ export const updateColumnItems = ({
   }
 }
 
+//다른 Draggable 이동으로 인한 업데이트
 export const moveItemBetweenColumns = ({
   startColumn,
   finishColumn,
@@ -92,4 +97,31 @@ export const moveItemBetweenColumns = ({
       items: finishItems
     }
   }
+}
+
+// 짝수
+const isEven = (id: number) => {
+  return id % 2 === 0
+}
+
+// 짝수 나열 체크 함수
+const canDropItemWithoutCreatingEvenSequence = ({
+  draggableId,
+  destinationIndex,
+  finishColumn
+}: canDropItemWithoutCreatingEvenSequenceParams) => {
+  const tempItems = finishColumn.items.filter(
+    item => item.id.toString() !== draggableId
+  )
+  const draggedItem: Item = { id: Number(draggableId), content: '' }
+
+  tempItems.splice(destinationIndex, 0, draggedItem)
+
+  for (let i = 0; i < tempItems.length - 1; i++) {
+    if (isEven(tempItems[i].id) && isEven(tempItems[i + 1].id)) {
+      return true
+    }
+  }
+
+  return false
 }

--- a/src/utils/dragConditionFn.ts
+++ b/src/utils/dragConditionFn.ts
@@ -1,0 +1,95 @@
+import { DragUpdate } from 'react-beautiful-dnd'
+import { Column } from '../data'
+
+interface UpdateColumnItemsParams {
+  sourceIndex: number
+  destinationIndex: number
+  currentColumnId: string
+  columns: Record<string, Column>
+}
+
+interface MoveItemBetweenColumnsParams {
+  startColumn: Column
+  finishColumn: Column
+  sourceIndex: number
+  destinationIndex: number
+  columns: Record<string, Column>
+}
+
+const isEven = (id: number) => {
+  return id % 2 === 0
+}
+
+export const isInvalidDropCondition = (
+  { destination, source, draggableId }: DragUpdate,
+  columns: Record<string, Column>
+): boolean => {
+  if (!destination) return false
+
+  if (
+    source.droppableId === 'column-1' &&
+    destination.droppableId === 'column-3'
+  ) {
+    return true
+  }
+
+  const finishColumn = columns[destination.droppableId]
+
+  if (
+    draggableId &&
+    isEven(Number(draggableId)) &&
+    ((destination.index > 0 &&
+      isEven(finishColumn.items[destination.index - 1]?.id)) ||
+      isEven(finishColumn.items[destination.index]?.id))
+  ) {
+    return true
+  }
+
+  return false
+}
+
+export const updateColumnItems = ({
+  sourceIndex,
+  destinationIndex,
+  currentColumnId,
+  columns
+}: UpdateColumnItemsParams): Record<string, Column> => {
+  const currentColumn = columns[currentColumnId]
+  const newItems = Array.from(currentColumn.items)
+  const [removed] = newItems.splice(sourceIndex, 1)
+  newItems.splice(destinationIndex, 0, removed)
+
+  return {
+    ...columns,
+    [currentColumnId]: {
+      ...currentColumn,
+      items: newItems
+    }
+  }
+}
+
+export const moveItemBetweenColumns = ({
+  startColumn,
+  finishColumn,
+  sourceIndex,
+  destinationIndex,
+  columns
+}: MoveItemBetweenColumnsParams): Record<string, Column> => {
+  const startItems = Array.from(startColumn.items)
+  const finishItems = Array.from(finishColumn.items)
+  const [removed] = startItems.splice(sourceIndex, 1)
+
+  finishItems.splice(destinationIndex, 0, removed)
+
+  return {
+    ...columns,
+    [startColumn.id]: {
+      ...startColumn,
+      items: startItems
+    },
+    [finishColumn.id]: {
+      ...finishColumn,
+      items: finishItems
+    }
+  }
+}


### PR DESCRIPTION
## 🌍 배경

> -첫 번째 칼럼에서 세 번째 칼럼으로는 아이템 이동이 불가능해야 합니다.
-짝수 아이템은 다른 짝수 아이템 앞으로 이동할 수 없습니다.
-이동할 수 없는 지점으로 아이템을 드래그 할 경우, 제약이 있음을 사용자가 알 수 있도록 합니다.
(ex. 드래그 중인 아이템의 색상이 붉은색으로 변경됨 등)

위 제약조건을 충족하는 DnD구현

## ✅ 작업 내용

1. `snapshot.isDragging` 으로 현재 드래깅 요소 상태 확인
2. `isInvalidDrop` 상태를 통해 제약 조건 확인
3. 짝수 아이템 나열되지 않도록 분기 처리
4. 이동할 수 없는 지점 `red` 색상으로 경고
5. `1 -> 3` 컬럼으로 가지 않도록 분기 처리
6.  아래는 더미 데이터 구조
```
{
    "column-1": {
        "id": "column-1",
        "title": "Column 1",
        "items": [
            {
                "id": 1,
                "content": "item-1",
                "isSelected": false
            },
            {
                "id": 2,
                "content": "item-2",
                "isSelected": false
            },
        ]
    },
    "column-2": {
        "id": "column-2",
        "title": "Column 2",
        "items": []
    },
    "column-3": {
        "id": "column-3",
        "title": "Column 3",
        "items": []
    },
    "column-4": {
        "id": "column-4",
        "title": "Column 4",
        "items": []
    }
}
```

## ✨시연영상


https://github.com/user-attachments/assets/a61d9632-df6e-4eab-af45-c45b731f65d4



##  🚨 특이사항

1. 아래 오류와 DnD 기능 동작 오류로 stritMode 제거
![image](https://github.com/user-attachments/assets/0306d55e-bc2e-4a22-8e1f-5a7ff9cb44e4)

2. react-beautiful 타입을 찾을 때 해당 [링크](https://github.com/atlassian/react-beautiful-dnd/blob/master/docs/guides/types.md) 사용
